### PR TITLE
feat(checkpoint): --modelDir accepts a checkpoint file; behavior-preserving core cleanup

### DIFF
--- a/Example/Minimal/main.py
+++ b/Example/Minimal/main.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Minimal entrypoint to smoke test JackFramework end-to-end."""
+
+from JackFramework import Application
+from minimal_interface import MinimalInterface
+
+
+if __name__ == '__main__':
+    Application(MinimalInterface(), application_name='JF-Minimal').start()
+

--- a/Example/Minimal/minimal_interface.py
+++ b/Example/Minimal/minimal_interface.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""Minimal, dependency-free user interface for smoke testing JackFramework."""
+
+from __future__ import annotations
+
+import argparse
+from typing import List, Sequence, Tuple
+
+import torch
+from torch import nn
+
+from JackFramework.UserTemplate.user_interface_template import NetWorkInferenceTemplate
+from JackFramework.UserTemplate.Models.ModelTemplate.model_template import (
+    ModelHandlerTemplate,
+)
+from JackFramework.UserTemplate.Dataloaders.datahandler_template import (
+    DataHandlerTemplate,
+)
+from JackFramework.SysBasic.log_handler import LogHandler as log
+
+
+class _RandomDataset(torch.utils.data.Dataset):
+    def __init__(self, length: int, input_shape: Tuple[int, int, int], label_dim: int) -> None:
+        super().__init__()
+        self.length = max(int(length), 0)
+        self.input_shape = input_shape
+        self.label_dim = label_dim
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return self.length
+
+    def __getitem__(self, idx: int):  # type: ignore[override]
+        x = torch.randn(self.input_shape, dtype=torch.float32)
+        y = torch.randn(self.label_dim, dtype=torch.float32)
+        return x, y
+
+
+class _MinimalModel(ModelHandlerTemplate):
+    def __init__(self, args: object, input_shape: Tuple[int, int, int], label_dim: int) -> None:
+        super().__init__(args)
+        c, h, w = input_shape
+        in_features = c * h * w
+        self._net = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(in_features, 64),
+            nn.ReLU(inplace=True),
+            nn.Linear(64, label_dim),
+        )
+
+    def get_model(self) -> Sequence[object]:
+        return [self._net]
+
+    def inference(self, model: nn.Module, input_data: List, model_id: int) -> List:
+        x = input_data[0]
+        return [model(x)]
+
+    def optimizer(self, model: Sequence[object], lr: float):
+        params = list(model[0].parameters())
+        opt = torch.optim.SGD(params, lr=lr, momentum=0.0)
+        return [opt], [None]
+
+    def lr_scheduler(self, sch: object, ave_loss: float, sch_id: int) -> None:
+        return None
+
+    def accuracy(self, output_data: List, label_data: List, model_id: int) -> List[float]:
+        # 1 - mean absolute error (for demo only)
+        out, lab = output_data[0], label_data[0]
+        return [1.0 - torch.mean(torch.abs(out - lab))]
+
+    def loss(self, output_data: List, label_data: List, model_id: int) -> List:
+        out, lab = output_data[0], label_data[0]
+        return [torch.nn.functional.mse_loss(out, lab)]
+
+
+class _MinimalData(DataHandlerTemplate):
+    def __init__(self, args: object, input_shape: Tuple[int, int, int], label_dim: int) -> None:
+        super().__init__(args)
+        self._shape = input_shape
+        self._label_dim = label_dim
+
+    def get_train_dataset(self, path: str, is_training: bool) -> object:
+        return _RandomDataset(self._args.imgNum, self._shape, self._label_dim)
+
+    def get_val_dataset(self, path: str) -> object:
+        return _RandomDataset(self._args.valImgNum, self._shape, self._label_dim)
+
+    def split_data(self, batch_data: Tuple, is_training: bool) -> List:
+        x, y = batch_data
+        return [x], [y]
+
+    def show_train_result(self, epoch: int, loss: List, acc: List, duration: float) -> None:
+        l0 = float(loss[0][0]) if loss and loss[0] else 0.0
+        a0 = float(acc[0][0]) if acc and acc[0] else 0.0
+        log.info(f"[TrainProcess] e: {epoch}, l0: {l0:.3f}, a0: {a0:.3f} ({duration if duration is not None else 0:.3f} s/epoch)")
+
+    def show_val_result(self, epoch: int, loss: List, acc: List, duration: float) -> None:
+        l0 = float(loss[0][0]) if loss and loss[0] else 0.0
+        a0 = float(acc[0][0]) if acc and acc[0] else 0.0
+        log.info(f"[ValProcess] e: {epoch}, l0: {l0:.3f}, a0: {a0:.3f} ({duration if duration is not None else 0:.3f} s/epoch)")
+
+    def save_result(self, output_data: List, supplement: List, img_id: int, model_id: int) -> None:
+        return None
+
+    def show_intermediate_result(self, epoch: int, loss: List, acc: List) -> str:
+        try:
+            l0 = float(loss[0][0]) if loss and loss[0] else 0.0
+            a0 = float(acc[0][0]) if acc and acc[0] else 0.0
+        except Exception:
+            l0, a0 = 0.0, 0.0
+        return f"e: {epoch}, l0: {l0:.3f}, a0: {a0:.3f}"
+
+
+class MinimalInterface(NetWorkInferenceTemplate):
+    """A tiny end-to-end setup producing random data and training a MLP."""
+
+    def __init__(self,
+                 input_shape: Tuple[int, int, int] = (3, 32, 32),
+                 label_dim: int = 10) -> None:
+        super().__init__()
+        self._input_shape = input_shape
+        self._label_dim = label_dim
+
+    def inference(self, args: object) -> Tuple[object, object]:
+        model = _MinimalModel(args, self._input_shape, self._label_dim)
+        data = _MinimalData(args, self._input_shape, self._label_dim)
+        return model, data
+
+    def user_parser(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+        # Provide a convenient minimal preset for quick runs
+        parser.add_argument('--mini_preset', default=True, type=self._str2bool,
+                            help='Use a tiny random dataset and short run (default: true)')
+        return parser
+

--- a/README.md
+++ b/README.md
@@ -108,6 +108,34 @@ Switch modes via `--mode <train|test|background|web>` when invoking your entry s
   ```
   The framework reuses `RANK` / `LOCAL_RANK` / `WORLD_SIZE`; only rank 0 prints to the terminal by default, while all ranks write `output.log`.
 
+## Smoke Test
+Run a dependency‑free minimal training to verify your environment end‑to‑end.
+
+- Minimal entrypoint
+  - `Example/Minimal/main.py` and `Example/Minimal/minimal_interface.py`
+  - Uses a tiny MLP on random data; no real datasets needed.
+
+- One‑command launcher
+  - `bash Scripts/run_minimal.sh`
+  - Defaults: CPU single‑process, `imgNum=32`, `batchSize=8`, `maxEpochs=1`, lists → `/dev/null`.
+  - Environment overrides:
+    - `DIST=true GPUS=2` for DDP (torchrun preferred, fallback to mp.spawn)
+    - `NOHUP=true LOG=run.log` to background with log file (colours enabled by default)
+    - `PASSTHRU="--your extra --flags"` appends flags to the Python command
+    - `TRAIN_LIST` / `VAL_LIST` to change list paths (default `/dev/null`)
+
+- Examples
+  - CPU: `bash Scripts/run_minimal.sh`
+  - Single‑node 2 GPUs (torchrun): `GPUS=2 DIST=true bash Scripts/run_minimal.sh`
+  - Background run: `NOHUP=true LOG=run.log bash Scripts/run_minimal.sh`
+
+- DDP troubleshooting tips
+  - Prefer `torchrun`; set explicit local IP/port if needed: `PASSTHRU="--ip 127.0.0.1 --port 29515"`
+  - Restrict visible GPUs: `CUDA_VISIBLE_DEVICES=0,1`
+  - If NCCL init hangs on some systems, try: `NCCL_IB_DISABLE=1 NCCL_P2P_DISABLE=1`
+  - See logs from all ranks: `JACK_LOG_ALL_RANKS=1`
+
+
 Common CLI flags
 | Flag | Default | Notes |
 |------|---------|-------|

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ Common CLI flags
 | `--trainListPath` / `--valListPath` | CSV | Dataset manifest paths. |
 | `--outputDir`, `--modelDir`, `--resultImgDir`, `--log` | ./Result/ | Output folders. |
 | `--debug` | `False` | Extra logging hints (e.g., unused params in DDP). |
+| `--dataloaderType` | `mapstyle` | `mapstyle` (Dataset + DataLoader + DistributedSampler, default) or `iterable` (IterableDataset, e.g. WebDataset; skips sampler/shuffle). |
+| `--dataloaderNum` | 8 | Number of DataLoader workers per rank. In `iterable` mode `persistent_workers=True` is hard-coded to avoid re-warmup at every epoch boundary. |
+| `--size_magnification` | 1 | Feature-map magnification factor (used by user modules). |
 
 ## Observability & Logging
 - TensorBoard writes to `--log`; launch with `tensorboard --logdir <log_dir>`.
@@ -216,6 +219,14 @@ Debug flag
 - About NCCL “destroy_process_group was not called” warnings: JackFramework explicitly tears down DDP across ranks at process exit. The warning may still appear on stderr in rare timing cases and can be ignored if every rank logs destruction as expected. You can temporarily silence C++ warnings via `TORCH_CPP_LOG_LEVEL=ERROR`.
 
 ## Changelog
+- 2026-05-16
+  - Added `--dataloaderType {mapstyle, iterable}` CLI flag and a separate
+    `__build_iterable_dataloader` path that omits `sampler`/`shuffle`
+    (PyTorch's `DistributedSampler` is a no-op on `IterableDataset`).
+  - Set `persistent_workers=True` on the iterable DataLoader so workers
+    survive across framework epochs — important for WebDataset-style
+    pipelines whose per-worker shuffle buffer is expensive to re-fill.
+  - Added `--nodes`, `--node_rank`, `--size_magnification`.
 - 2025-09-18
   - Hardened runtime validation across graph/mode/device helpers.
   - Synced packaging version info (`0.1.1`).

--- a/Scripts/run_minimal.sh
+++ b/Scripts/run_minimal.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Quick launcher for the minimal JackFramework smoke test.
+#
+# Usage examples:
+#   # CPU single-process
+#   bash Scripts/run_minimal.sh
+#
+#   # Single node, 2 GPUs with torchrun if available (else mp.spawn)
+#   GPUS=2 DIST=true bash Scripts/run_minimal.sh
+#
+#   # nohup with coloured progress to file
+#   NOHUP=true LOG=run.log bash Scripts/run_minimal.sh
+#
+# Tunables via env (defaults shown):
+#   PYTHON=python
+#   DIST=false         # true to enable DDP
+#   GPUS=0             # number of GPUs for DDP
+#   EPOCHS=1 IMGS=32 VAL_IMGS=0 BATCH=8 DEBUG=false
+#   NOHUP=false LOG=Result/run-minimal.log
+#   TRAIN_LIST=/dev/null VAL_LIST=/dev/null   # override list paths if needed
+#   JF_PROGRESS_COLOR=1  # coloured progress (set 0 or NO_COLOR=1 to disable)
+#   PASSTHRU="--your extra --flags here"     # appended to the Python cmd
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON="${PYTHON:-python}"
+ENTRY="$ROOT_DIR/Example/Minimal/main.py"
+
+export PYTHONPATH="$ROOT_DIR/Source:${PYTHONPATH:-}"
+
+# Defaults
+DIST="${DIST:-false}"
+GPUS="${GPUS:-0}"
+EPOCHS="${EPOCHS:-1}"
+IMGS="${IMGS:-32}"
+VAL_IMGS="${VAL_IMGS:-0}"
+BATCH="${BATCH:-8}"
+DEBUG="${DEBUG:-false}"
+NOHUP_RUN="${NOHUP:-false}"
+LOG_FILE="${LOG:-$ROOT_DIR/Result/run-minimal.log}"
+TRAIN_LIST="${TRAIN_LIST:-/dev/null}"
+VAL_LIST="${VAL_LIST:-/dev/null}"
+PASSTHRU="${PASSTHRU:-}"
+
+# Coloured progress by default; honour NO_COLOR/JF_PROGRESS_COLOR if already set
+export JF_PROGRESS_COLOR="${JF_PROGRESS_COLOR:-1}"
+
+declare -a CMD
+if [[ "$DIST" == "true" && "$GPUS" -gt 0 ]]; then
+  if command -v torchrun >/dev/null 2>&1; then
+    CMD=(torchrun --nproc_per_node="$GPUS" "$ENTRY" --dist true --gpu "$GPUS")
+  else
+    CMD=("$PYTHON" "$ENTRY" --dist true --gpu "$GPUS")
+  fi
+else
+  CMD=("$PYTHON" "$ENTRY" --dist false --gpu 0)
+fi
+
+# Common training knobs
+CMD+=(--imgNum "$IMGS" --valImgNum "$VAL_IMGS" --batchSize "$BATCH" --maxEpochs "$EPOCHS" --debug "$DEBUG")
+# Minimal interface ignores list contents, but init checks path existence.
+CMD+=(--trainListPath "$TRAIN_LIST" --valListPath "$VAL_LIST")
+
+# Append any extra user-provided flags
+if [[ -n "${PASSTHRU}" ]]; then
+  # shellcheck disable=SC2206
+  EXTRA=( ${PASSTHRU} )
+  CMD+=("${EXTRA[@]}")
+fi
+
+echo "[run_minimal] PYTHONPATH=$PYTHONPATH"
+echo "[run_minimal] TRAIN_LIST=$TRAIN_LIST VAL_LIST=$VAL_LIST"
+echo "[run_minimal] CMD: ${CMD[*]}"
+
+if [[ "$NOHUP_RUN" == "true" ]]; then
+  mkdir -p "$(dirname "$LOG_FILE")"
+  # Use nohup for background; preserve colours in the log when JF_PROGRESS_COLOR=1
+  nohup "${CMD[@]}" >"$LOG_FILE" 2>&1 &
+  echo "[run_minimal] Started in background (PID $!). Log: $LOG_FILE"
+else
+  exec "${CMD[@]}"
+fi

--- a/Source/JackFramework/Core/Graph/_loss_computer.py
+++ b/Source/JackFramework/Core/Graph/_loss_computer.py
@@ -44,7 +44,7 @@ class ResultContainer(object):
         self._tower_loss = ListHandler.double_list_add(self._tower_loss_iteration, self._tower_loss)
         self._ave_tower_loss = ListHandler.double_list_div(self._tower_loss, total_iteration)
 
-    def cal_acc(self, total_iteration) -> None:
+    def cal_acc(self, total_iteration: int) -> None:
         self._tower_acc = ListHandler.double_list_add(self._tower_acc_iteration, self._tower_acc)
         self._ave_tower_acc = ListHandler.double_list_div(self._tower_acc, total_iteration)
 

--- a/Source/JackFramework/Core/Graph/_meta_ops.py
+++ b/Source/JackFramework/Core/Graph/_meta_ops.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 from abc import ABCMeta, abstractmethod
-from typing import TypeVar
 
 import torch
 from torch import nn
@@ -16,14 +15,12 @@ from JackFramework.FileHandler.model_saver import ModelSaver
 
 from ._user_model import UserModel
 
-ModelHandlerTemplate = TypeVar('ModelHandlerTemplate')
-
 
 class MetaOps(UserModel):
     __metaclass__ = ABCMeta
     __OPT_LR_GROUP_ID = 0
 
-    def __init__(self, args: object, jf_model: ModelHandlerTemplate) -> None:
+    def __init__(self, args: object, jf_model: object) -> None:
         super().__init__(args, jf_model)
         self.__args = args
         self.__device_manager = DeviceManager(args)
@@ -57,11 +54,11 @@ class MetaOps(UserModel):
         use_cuda = (self.__args.gpu > 0) and torch.cuda.is_available()
         # If multiple GPUs requested and CUDA available, wrap with DataParallel.
         # For single GPU or CPU, keep the raw module and move to the resolved device.
-        if use_cuda and max(self.__args.gpu, 0) > 1:
+        if use_cuda and self.__args.gpu > 1:
+            # Multi-GPU: wrap each model in DataParallel and move to device.
+            # 多卡：把每个模型包成 DataParallel 并移到设备。
             for i, model_item in enumerate(self._model):
-                self._model[i] = nn.DataParallel(model_item)
-            for i, _ in enumerate(self._model):
-                self._model[i].to(self.__device)
+                self._model[i] = nn.DataParallel(model_item).to(self.__device)
         else:
             for i, model_item in enumerate(self._model):
                 self._model[i] = model_item.to(self.__device)

--- a/Source/JackFramework/Core/Graph/data_handler_manager.py
+++ b/Source/JackFramework/Core/Graph/data_handler_manager.py
@@ -71,7 +71,7 @@ class DataHandlerManager(UserDataloader):
         log.info("Finish constructing the training dataloader")
         return training_dataloader, training_sampler
 
-    def __check_val_dataloader(self) -> object:
+    def __check_val_dataloader(self) -> tuple:
         log.info("Begin loading the val dataset")
         if self.__args.valImgNum > 0:
             val_dataloader, val_sampler = self.__init_val_dataloader()

--- a/Source/JackFramework/Core/Graph/data_handler_manager.py
+++ b/Source/JackFramework/Core/Graph/data_handler_manager.py
@@ -31,6 +31,8 @@ class DataHandlerManager(UserDataloader):
 
     def __init_training_dataloader(self, is_training: bool) -> tuple:
         training_dataset = self.user_get_train_dataset(is_training)
+        if self.__is_iterable_mode():
+            return self.__build_iterable_dataloader(training_dataset), None
         training_sampler, dataloader_shuffle = self.__get_sampler_shuffle(training_dataset,
                                                                           is_training)
         training_dataloader = torch.utils.data.DataLoader(
@@ -41,11 +43,22 @@ class DataHandlerManager(UserDataloader):
 
     def __init_val_dataloader(self) -> tuple:
         val_dataset = self.user_get_val_dataset()
+        if self.__is_iterable_mode():
+            return self.__build_iterable_dataloader(val_dataset), None
         val_sampler, _ = self.__get_sampler_shuffle(val_dataset, False)
         val_dataloader = torch.utils.data.DataLoader(
             val_dataset, batch_size=self.__args.batchSize, num_workers=self.__args.dataloaderNum,
             pin_memory=True, sampler=val_sampler, collate_fn=self.__collate_fn(val_dataset))
         return val_dataloader, val_sampler
+
+    def __is_iterable_mode(self) -> bool:
+        return getattr(self.__args, 'dataloaderType', 'mapstyle') == 'iterable'
+
+    def __build_iterable_dataloader(self, dataset: object) -> object:
+        return torch.utils.data.DataLoader(
+            dataset, batch_size=self.__args.batchSize,
+            num_workers=self.__args.dataloaderNum, pin_memory=True, persistent_workers=True,
+            collate_fn=self.__collate_fn(dataset))
 
     def __check_training_dataloader(self) -> tuple:
         log.info("Begin loading the training dataset")

--- a/Source/JackFramework/Core/Mode/_meta_mode.py
+++ b/Source/JackFramework/Core/Mode/_meta_mode.py
@@ -55,8 +55,10 @@ class MetaMode(ShowHandler, metaclass=ABCMeta):
     def _get_img_id(self, iteration: int) -> int:
         if self.rank is None:
             return iteration
-        per_rank = self._args.batchSize * max(self._args.gpu, 1)
-        return self.rank + iteration * per_rank
+        # Global stride per optimisation step across all ranks: batch x gpu.
+        # 每个优化步跨所有 rank 的全局步长：batch x gpu。
+        step_stride = self._args.batchSize * max(self._args.gpu, 1)
+        return self.rank + iteration * step_stride
 
     def _save_result(self, iteration: int, outputs_data: list, supplement: list) -> None:
         if self._data_manager is None:

--- a/Source/JackFramework/Core/Mode/test_proc.py
+++ b/Source/JackFramework/Core/Mode/test_proc.py
@@ -14,7 +14,9 @@ class TestProc(MetaMode):
         if self._graph is None or self._data_manager is None:
             raise RuntimeError('Graph or data manager not initialised before testing loop.')
 
-        self._graph.set_model_mode(True)
+        # Test always runs in eval mode; the (test) loader is fetched via the
+        # is_training=True slot, then the model is switched to eval once.
+        # 测试一律 eval 模式：经 is_training=True 槽位取（测试）loader，随后置 eval。
         dataloader = self._data_manager.get_dataloader(True)
         if dataloader is None:
             log.warning('No testing dataloader available; skipping test execution.')

--- a/Source/JackFramework/Core/Mode/train_proc.py
+++ b/Source/JackFramework/Core/Mode/train_proc.py
@@ -55,12 +55,21 @@ class TrainProc(MetaMode):
     def __executor_training_proc(self, epoch: int) -> None:
         if self._training_iteration > 0:
             total_iteration = self.__run_epoch(epoch, self._training_iteration, 'Train', True)
-            self.set_training_iteration(total_iteration)
+            # Only adopt the measured count when the epoch actually produced
+            # batches; an empty loader (0 batches) must not latch training off
+            # for every later epoch.
+            # 只有真正跑出 batch 时才采用实测迭代数；空 loader（0 batch）不能把后续
+            # 所有 epoch 都静默关掉。
+            if total_iteration > 0:
+                self.set_training_iteration(total_iteration)
 
     def __executor_val_proc(self, epoch: int) -> None:
         if self._val_iteration > 0:
             total_iteration = self.__run_epoch(epoch, self._val_iteration, 'Val', False)
-            self.set_val_iteration(total_iteration)
+            # Same guard as training: don't let an empty val epoch disable later ones.
+            # 与训练同理：空的验证 epoch 不应关闭后续验证。
+            if total_iteration > 0:
+                self.set_val_iteration(total_iteration)
 
     def _adjust_lr_scheduler_and_post_proc(self, epoch: int, is_training: bool) -> None:
         if is_training:

--- a/Source/JackFramework/Core/application.py
+++ b/Source/JackFramework/Core/application.py
@@ -6,7 +6,6 @@ from collections.abc import Callable
 from typing import Optional, Tuple
 
 import torch.multiprocessing as mp
-import torch.distributed as dist
 
 from JackFramework.SysBasic.args_parser import ArgsParser
 from JackFramework.SysBasic.init_handler import InitProgram
@@ -40,7 +39,6 @@ class Application(object):
         args = self.__parse_args()
         # Apply logging/warning controls and stderr filter as early as possible
         try:
-            from JackFramework.SysBasic.init_handler import InitProgram
             InitProgram.apply_runtime_logging(args)
         except Exception:
             pass
@@ -91,7 +89,6 @@ def _spawn_mode_worker(local_rank: int, mode_func: Callable, node_rank: int, gpu
     """Entry point for spawned worker processes."""
     # Apply logging/warnings controls early in the child process
     try:
-        from JackFramework.SysBasic.init_handler import InitProgram
         InitProgram.apply_runtime_logging(args)
     except Exception:
         pass

--- a/Source/JackFramework/Evaluation/listhandler.py
+++ b/Source/JackFramework/Evaluation/listhandler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Utility helpers for common list-based tensor aggregations."""
 
-from typing import Iterable, List, Sequence
+from typing import List, Sequence
 
 
 class ListHandler(object):

--- a/Source/JackFramework/FileHandler/model_saver.py
+++ b/Source/JackFramework/FileHandler/model_saver.py
@@ -47,9 +47,24 @@ class ModelSaver(object):
 
     @staticmethod
     def __normalize_dir(path: str) -> Path:
+        """Resolve *path* to the directory new checkpoints are written into.
+
+        把 *path* 归一化为新 checkpoint 的写入目录。
+
+        Args:
+            path: A directory, or a checkpoint file such as
+                ``--modelDir run/model_epoch_2.pth``. When a file is given, new
+                checkpoints are written **alongside it**, i.e. into its parent.
+                可以是目录，也可以是 checkpoint 文件（如
+                ``--modelDir run/model_epoch_2.pth``）；给文件时，新的 checkpoint
+                写入它的**同级目录**。
+
+        Returns:
+            The existing directory to write into. 可写入的目录（已确保存在）。
+        """
         target = Path(path).expanduser()
         if target.is_file():
-            raise ValueError(f'Expected directory path, received file: {target}')
+            target = target.parent
         target.mkdir(parents=True, exist_ok=True)
         return target
 

--- a/Source/JackFramework/SysBasic/args_parser.py
+++ b/Source/JackFramework/SysBasic/args_parser.py
@@ -45,6 +45,12 @@ class ArgsParser(object):
                             help='number of checkpoints to keep automatically')
         parser.add_argument('--dataloaderNum', type=int, default=sys_define.DATA_LOADER_NUM,
                             help='the number of DataLoader workers')
+        parser.add_argument('--dataloaderType', default='mapstyle',
+                            choices=['mapstyle', 'iterable'],
+                            help='dataloader type: "mapstyle" (default, original '
+                                 'Dataset+DataLoader path) or "iterable" (for '
+                                 'WebDataset-style IterableDataset; shuffle/sampler '
+                                 'are not used in this mode)')
         parser.add_argument('--pretrain', default=False, type=ArgsParser.__str2bool,
                             help='load pretrained checkpoint if true')
         parser.add_argument('--ip', default=sys_define.IP, help='master address for distributed mode')

--- a/Source/JackFramework/SysBasic/device_manager.py
+++ b/Source/JackFramework/SysBasic/device_manager.py
@@ -83,12 +83,11 @@ class DeviceManager(object):
         # Best-effort: ensure PG is destroyed on any interpreter exit path
         if not DeviceManager.__ATEEXIT_REGISTERED:
             def _dist_cleanup_on_exit() -> None:
+                # Best-effort: tear down the process group on any exit path.
+                # 尽力而为：在任意退出路径上销毁进程组。
                 try:
                     if dist.is_initialized():
-                        try:
-                            dist.destroy_process_group()
-                        except Exception:
-                            pass
+                        dist.destroy_process_group()
                 except Exception:
                     pass
 

--- a/Source/JackFramework/SysBasic/init_handler.py
+++ b/Source/JackFramework/SysBasic/init_handler.py
@@ -35,6 +35,13 @@ class InitProgram(object):
     def __build_result_directory(self) -> None:
         for path in (self.__args.outputDir, self.__args.modelDir,
                      self.__args.resultImgDir, self.__args.log):
+            # `--modelDir` may point straight at a checkpoint file to load; the
+            # directory that has to exist is then the one holding that file.
+            # `--modelDir` 允许直接指向要加载的 checkpoint 文件；此时需要存在的是
+            # 该文件所在的目录，而不是把文件名本身当目录去创建。
+            if os.path.isfile(path):
+                FileHandler.mkdir(os.path.dirname(os.path.abspath(path)))
+                continue
             FileHandler.mkdir(path)
 
     def __show_args(self) -> None:
@@ -87,7 +94,11 @@ class InitProgram(object):
                 if reporter is log.error:
                     result = False
 
-        for directory in ('outputDir', 'modelDir', 'resultImgDir', 'log'):
+        # `--modelDir` is deliberately exempt: it accepts either a directory
+        # (holding a checkpoint.list) or a checkpoint file to load directly.
+        # `--modelDir` 特意豁免：既可以是目录（内含 checkpoint.list），也可以直接
+        # 是要加载的 checkpoint 文件。
+        for directory in ('outputDir', 'resultImgDir', 'log'):
             value = getattr(self.__args, directory)
             if os.path.isfile(value):
                 log.error(f'A file was passed as `--{directory}`, please pass a directory!')

--- a/Source/JackFramework/SysBasic/init_handler.py
+++ b/Source/JackFramework/SysBasic/init_handler.py
@@ -18,6 +18,16 @@ from .device_manager import DeviceManager
 class InitProgram(object):
     """Prepare directories, logging, and device sanity checks."""
 
+    # Per-process guard: the stderr filter must be installed at most once.
+    # start() and init_program() both call __configure_runtime_logging(); a
+    # class flag (NOT an env var) de-duplicates within a process while still
+    # letting each spawned worker — which re-imports this module with the flag
+    # reset to False — install exactly once.
+    # 单进程内 stderr 过滤器最多安装一次的标志。start() 与 init_program() 都会
+    # 触发安装；用类标志（而非环境变量）在进程内去重，同时让每个 spawn 子进程
+    # （重新导入本模块、标志复位为 False）各自恰好安装一次。
+    __STDERR_FILTER_INSTALLED = False
+
     def __init__(self, args) -> None:
         super().__init__()
         self.__args = args
@@ -175,6 +185,12 @@ class InitProgram(object):
             env['JF_PROGRESS_COLOR'] = '1'
 
     def __install_stderr_filter(self) -> None:
+        # Install at most once per process; a second call (start() then
+        # init_program()) would leak an fd pair + a pump thread.
+        # 每个进程最多安装一次；第二次调用（start() 后再 init_program()）会
+        # 泄漏一对 fd 和一个 pump 线程。
+        if InitProgram.__STDERR_FILTER_INSTALLED:
+            return
         env = os.environ
         debug = getattr(self.__args, 'debug', False)
 
@@ -206,16 +222,28 @@ class InitProgram(object):
 
         # Filter only stderr to avoid interfering with live stdout rendering
         # (e.g., progress bars) and to preserve TTY colour detection.
-        self.__install_stream_filter(sys.stderr, compiled, name='stderr')
+        # Mark installed only on success so a failed attempt can still retry.
+        # 仅在成功后置位标志，失败的尝试仍可重试。
+        if self.__install_stream_filter(sys.stderr, compiled, name='stderr'):
+            InitProgram.__STDERR_FILTER_INSTALLED = True
 
     @staticmethod
-    def __install_stream_filter(stream, compiled_patterns, name: str = 'stderr') -> None:
+    def __install_stream_filter(stream, compiled_patterns, name: str = 'stderr') -> bool:
+        """Redirect ``stream`` through a regex drop-filter pump thread.
+
+        把 ``stream`` 经一个正则丢弃过滤的 pump 线程做重定向。
+
+        Returns:
+            True if the filter was installed, False if it bailed out early
+            (no fileno / dup / dup2 failure).
+            成功安装返回 True；提前退出（无 fileno / dup / dup2 失败）返回 False。
+        """
         if not hasattr(stream, 'fileno'):
-            return
+            return False
         try:
             orig_fd = os.dup(stream.fileno())
         except Exception:
-            return
+            return False
 
         # Preserve color capability hint when filtering stdout
         try:
@@ -231,7 +259,7 @@ class InitProgram(object):
             os.close(r_fd)
             os.close(w_fd)
             os.close(orig_fd)
-            return
+            return False
 
         stop_flag = threading.Event()
 
@@ -285,6 +313,7 @@ class InitProgram(object):
                 pass
 
         atexit.register(_cleanup)
+        return True
 
     def init_program(self) -> bool:
         args = self.__args

--- a/Source/JackFramework/SysBasic/process_bar.py
+++ b/Source/JackFramework/SysBasic/process_bar.py
@@ -20,11 +20,11 @@ class ShowProcess(object):
     # ANSI styles
     _RESET = '\033[0m'
     _STYLE = {
-        'info': '\033[1;36m',          # bold cyan
+        'info': '\033[1;35m',          # bold magenta
         'spinner': '\033[1;33m',       # bold yellow
-        'bar_fill': '\033[1;32m',      # bold green
+        'bar_fill': '\033[1;34m',      # bold blue
         'bar_empty': '\033[90m',       # bright black (dim)
-        'bar_pointer': '\033[1;35m',   # bold magenta
+        'bar_pointer': '\033[1;36m',   # bold cyan
         'count': '\033[1;37m',         # bold white
         'percent': '\033[1;36m',       # bold cyan
         'sep': '\033[90m',             # dim separator
@@ -68,9 +68,17 @@ class ShowProcess(object):
         if env.get('JF_PROGRESS_COLOR') == '1':
             return True
         try:
-            return sys.stdout.isatty()
+            if hasattr(sys, 'stdout') and sys.stdout and sys.stdout.isatty():
+                return True
+            # Fallback to original stdout, useful if fd 1 is temporarily piped
+            if hasattr(sys, '__stdout__') and sys.__stdout__ and sys.__stdout__.isatty():
+                return True
         except Exception:
-            return False
+            pass
+        # If a pre-filter captured TTY state, trust it
+        if os.environ.get('JF_STDOUT_WAS_TTY') == '1':
+            return True
+        return False
 
     def __fmt(self, text: str, style_key: Optional[str]) -> str:
         if not self.__use_color or not style_key:

--- a/Source/JackFramework/SysBasic/result_str.py
+++ b/Source/JackFramework/SysBasic/result_str.py
@@ -10,7 +10,16 @@ DEFAULT_MIN_DECIMAL_PLACES = 2
 class ResultStr(object):
     """Generate pre-formatted log strings for losses and metrics."""
 
-    def __init__(self, arg=None) -> None:
+    def __init__(self, arg: Optional[object] = None) -> None:
+        """Create a result formatter.
+
+        创建结果格式化器。
+
+        Args:
+            arg: Reserved for future configuration; accepted for API
+                compatibility but currently unused.
+                预留的配置参数，仅为兼容接口而保留，目前未使用。
+        """
         super().__init__()
         self.__arg = arg
 

--- a/Source/JackFramework/SysBasic/switch.py
+++ b/Source/JackFramework/SysBasic/switch.py
@@ -10,9 +10,15 @@ class Switch(object):
         self.__fall = False
 
     def __iter__(self) -> Iterator:
-        """Return the match method once, then stop."""
+        """Yield the match callable once, then stop iteration.
+
+        产出一次 match 可调用对象后即停止迭代。
+        """
+        # A generator naturally raises StopIteration when exhausted; no
+        # explicit return value is needed (and `return StopIteration` would
+        # wrongly set the class object as the generator's return value).
+        # 生成器耗尽时会自动抛出 StopIteration，无需显式返回值。
         yield self.match
-        return StopIteration
 
     def match(self, *args: Any) -> bool:
         """Indicate whether to enter a case suite."""

--- a/Source/JackFramework/UserTemplate/Dataloaders/datahandler_template.py
+++ b/Source/JackFramework/UserTemplate/Dataloaders/datahandler_template.py
@@ -4,8 +4,33 @@
 from abc import ABCMeta, abstractmethod
 from typing import List, Tuple
 
+from JackFramework.UserTemplate._hook_validator import validate_hook_names
+
 
 class DataHandlerTemplate(object, metaclass=ABCMeta):
+    # Optional hooks JF dispatches via getattr; subclasses MAY override.
+    # 框架可选 hook 名册，写错时 __init_subclass__ 报错。
+    _OPTIONAL_HOOKS = frozenset({
+        'load_test_data', 'save_test_data',
+    })
+    # Hard typo blacklist.
+    # 硬黑名单。
+    _HOOK_NAME_TYPOS = {
+        'loadtestdata': 'load_test_data',
+        'savetestdata': 'save_test_data',
+        'load_testdata': 'load_test_data',
+        'save_testdata': 'save_test_data',
+    }
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        validate_hook_names(
+            cls,
+            optional_hooks=cls._OPTIONAL_HOOKS,
+            typo_map=cls._HOOK_NAME_TYPOS,
+            template_name='DataHandlerTemplate',
+        )
+
     def __init__(self, args: object) -> None:
         super().__init__()
         self._args = args

--- a/Source/JackFramework/UserTemplate/Models/ModelTemplate/model_template.py
+++ b/Source/JackFramework/UserTemplate/Models/ModelTemplate/model_template.py
@@ -4,8 +4,39 @@
 from abc import ABCMeta, abstractmethod
 from typing import List, Sequence, Tuple
 
+from JackFramework.UserTemplate._hook_validator import validate_hook_names
+
 
 class ModelHandlerTemplate(object, metaclass=ABCMeta):
+    # Optional hooks JF dispatches via getattr; subclasses MAY override
+    # any subset. Listed here so ``__init_subclass__`` can catch typos
+    # at class-definition time (e.g. ``postprocess`` vs ``post_process``).
+    # 框架可选 hook 名册，写错时 __init_subclass__ 报错。
+    _OPTIONAL_HOOKS = frozenset({
+        'pretreatment', 'post_process',
+        'load_model', 'load_opt', 'save_model',
+    })
+    # Hard typo blacklist (names we've actually seen in real projects).
+    # 硬黑名单：踩过的拼写错。
+    _HOOK_NAME_TYPOS = {
+        'postprocess':    'post_process',
+        'postProcess':    'post_process',
+        'preprocess':     'pretreatment',
+        'pretrain':       'pretreatment',
+        'loadmodel':      'load_model',
+        'savemodel':      'save_model',
+        'load_optimizer': 'load_opt',
+    }
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        validate_hook_names(
+            cls,
+            optional_hooks=cls._OPTIONAL_HOOKS,
+            typo_map=cls._HOOK_NAME_TYPOS,
+            template_name='ModelHandlerTemplate',
+        )
+
     def __init__(self, args: object) -> None:
         super().__init__()
         self._args = args

--- a/Source/JackFramework/UserTemplate/_hook_validator.py
+++ b/Source/JackFramework/UserTemplate/_hook_validator.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Class-definition-time validator for JF user-hook method names.
+
+Catches the silent-dispatch trap where a user subclass defines a method
+with a name JF doesn't actually call (e.g. ``postprocess`` instead of
+``post_process``), which would otherwise just be silently skipped at
+runtime.
+
+类定义时校验 user hook 方法名，避免拼写错被 framework 静默 skip。
+"""
+from __future__ import annotations
+
+import difflib
+import warnings
+from typing import FrozenSet, Mapping
+
+
+def validate_hook_names(
+    cls: type,
+    optional_hooks: FrozenSet[str],
+    typo_map: Mapping[str, str],
+    template_name: str,
+    fuzzy_cutoff: float = 0.85,
+) -> None:
+    """Scan a subclass's own attributes for likely hook-name typos.
+
+    扫描子类自身定义的方法名，发现疑似 hook 拼写错就报错或警告。
+
+    Args:
+        cls: The subclass being validated (passed by ``__init_subclass__``).
+        optional_hooks: Names of optional JF hooks the subclass MAY
+            override. Anything in this set is whitelisted.
+        typo_map: Hard blacklist mapping wrong-name → correct-name.
+            Names in this dict trigger ``TypeError`` immediately.
+        template_name: Human-readable name of the parent template
+            (e.g. ``"ModelHandlerTemplate"``) used in the error message.
+        fuzzy_cutoff: ``difflib`` similarity threshold for the soft warn
+            pass (0.85 = quite strict; rare false positives).
+
+    Raises:
+        TypeError: if a name in ``typo_map`` appears in ``vars(cls)``.
+
+    Note:
+        Only inspects attributes defined directly on ``cls``
+        (``vars(cls)``), not inherited ones. Private names (starting
+        with underscore) are skipped. Non-callable attributes are
+        skipped.
+    """
+    own_attrs = vars(cls)
+    for name in own_attrs:
+        if name.startswith('_'):
+            continue
+        attr = own_attrs[name]
+        if not callable(attr):
+            continue
+        # Hard blacklist: known-bad name → fail loudly with the fix.
+        # 硬黑名单：踩过的拼写错直接报错。
+        if name in typo_map:
+            raise TypeError(
+                f"{cls.__name__} defines method `{name}`, but "
+                f"{template_name} dispatches `{typo_map[name]}`. "
+                f"Rename to fix silent skip."
+            )
+        if name in optional_hooks:
+            continue
+        # Soft fuzzy: warn if this name is suspiciously close to a hook.
+        # 软模糊：跟某个 hook 名很像就 warn。
+        match = difflib.get_close_matches(
+            name, optional_hooks, n=1, cutoff=fuzzy_cutoff)
+        if match:
+            warnings.warn(
+                f"{cls.__name__}.{name} looks similar to {template_name} "
+                f"hook `{match[0]}`. If unrelated, ignore; if you meant "
+                f"to override the hook, rename to match.",
+                stacklevel=3,
+            )


### PR DESCRIPTION
## Summary

Brings the `refactor/behavior-preserving-cleanup` branch to `master`. The headline
change is that **`--modelDir` now accepts a checkpoint file, not only a directory**;
the branch also carries four earlier behavior-preserving cleanups.

### `--modelDir` takes a file (this PR's new commit)

`ModelSaver.get_check_point_path()` already handled both a file and a directory, but
the CLI could never reach the file branch:

- init bootstrap unconditionally `mkdir`'d every path argument, so an existing `.pth`
  raised `Unable to create directory because a file already exists`;
- the arg check then rejected files for `--modelDir` outright.

Changes:

- `init_handler.__build_result_directory` — when the path is a file, create its parent
  directory instead of trying to mkdir the file name.
- `init_handler.__check_paths` — exempt `--modelDir` (`outputDir` / `resultImgDir` /
  `log` still require directories).
- `model_saver.__normalize_dir` — a checkpoint file resolves to its parent, so new
  checkpoints and `checkpoint.list` are written **alongside** the file passed in
  instead of raising `ValueError`.

`--modelDir` now accepts either form: a directory holding a `checkpoint.list`, or a
checkpoint file to load directly.

### Also on this branch (pre-existing commits)

- `refactor(core)`: behavior-preserving cleanup + fix empty-loader latch & stderr double-install
- `feat(templates)`: catch user-hook typos at class definition
- `feat(iterable dataloader)`: `--dataloaderType` + `persistent_workers`
- `docs(readme)`: Smoke Test section

## Verification

Tested end-to-end on two GPU servers with `--mode test`:

- loading `Checkpoint_B_256/model_epoch_4.pth` directly → `Begin loading checkpoint from this file` → `Finish testing process!`
- loading `Checkpoint_C_phase2_8gpu/model_epoch_2.pth` directly → same
- save probe: passing `run_dir/model_epoch_2.pth` writes `run_dir/model_epoch_3.pth` +
  `run_dir/checkpoint.list`, with no stray directory created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cbeju55q6Nk2mFk1yR8C8a

## Summary by Sourcery

Support using --modelDir with either a checkpoint directory or file while tightening runtime behavior around logging, data loading, and distributed execution, and add a minimal end-to-end smoke test example.

New Features:
- Allow --modelDir to point directly at a checkpoint file in addition to a directory.
- Introduce an iterable DataLoader mode selectable via the new --dataloaderType CLI flag with persistent workers.
- Add class-definition-time hook name validation for user model and dataloader templates to catch common typos.
- Provide a minimal MLP-based example interface and script for dependency-free smoke testing of JackFramework.

Enhancements:
- Ensure stderr log filtering is installed at most once per process, improves pattern coverage, and preserves progress bar behavior and TTY color hints.
- Default progress bars to colored output unless explicitly disabled and make color detection more robust.
- Relax DataParallel wrapping so single-GPU/CPU runs keep raw modules and only multi-GPU runs are wrapped, while consistently moving models to the target device.
- Respect torchrun/elastic environment variables when initializing distributed GPU devices and simplify process group teardown.
- Guard training and validation iteration latching to avoid permanently disabling epochs when a loader is temporarily empty.
- Improve img-id calculation for multi-rank runs and clarify test mode behavior setting models to eval.
- Improve model checkpoint loading by adapting state_dict key prefixes between plain and module.-prefixed layouts with strict/non-strict fallbacks.
- Refine stderr filtering internals to handle installation failures gracefully and reduce resource leaks.
- Polish progress bar color palette and strengthen TTY detection using original stdout and env hints.
- Tighten various core utilities with clearer typing and docstrings, keeping behavior intact.

Documentation:
- Document the new smoke test workflow, including minimal example, launcher script, and DDP troubleshooting tips.
- Extend README CLI docs with --dataloaderType, --dataloaderNum iterable-mode behavior, and size_magnification.
- Update changelog with iterable dataloader, new CLI flags, and related behavior.

Tests:
- Add a minimal random-data MLP example and launcher script that exercises training, validation, logging, and distributed setup as a framework smoke test.