### PR TITLE
docs(skill): Claude Code skill for using and debugging JackFramework

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "jackframework",
+  "description": "Claude Code extensions for JackFramework, a PyTorch training framework that owns the training loop, DDP launcher and checkpoint I/O.",
+  "owner": {
+    "name": "Archaic-Atom",
+    "url": "https://github.com/Archaic-Atom"
+  },
+  "plugins": [
+    {
+      "name": "jackframework",
+      "description": "Build on, launch, and debug JackFramework: the hook contract (inference / loss / accuracy / post_process / get_train_dataset / save_result), the CLI flags, checkpoint and checkpoint.list semantics, and a symptom-to-cause catalog for the framework's silent failure modes.",
+      "author": {
+        "name": "Archaic-Atom"
+      },
+      "category": "development",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/Archaic-Atom/JackFramework.git",
+        "path": "plugins/jackframework",
+        "ref": "master"
+      },
+      "homepage": "https://github.com/Archaic-Atom/JackFramework/tree/master/plugins/jackframework"
+    }
+  ]
+}

--- a/plugins/jackframework/.claude-plugin/plugin.json
+++ b/plugins/jackframework/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "jackframework",
+  "description": "Build on, launch, and debug JackFramework: the hook contract, CLI flags, checkpoint semantics, and a symptom-to-cause catalog for the framework's silent failure modes.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Archaic-Atom"
+  },
+  "homepage": "https://github.com/Archaic-Atom/JackFramework"
+}

--- a/plugins/jackframework/README.md
+++ b/plugins/jackframework/README.md
@@ -1,0 +1,69 @@
+# JackFramework skill for Claude Code
+
+A [Claude Code](https://claude.com/claude-code) skill that teaches the assistant how
+JackFramework actually behaves — so it stops guessing when a run fails.
+
+JF is built around string dispatch and a per-project config: it owns the training loop,
+DDP launcher, checkpoint I/O, logging and progress bar, while you supply a
+model-interface class, a dataloader class and a launcher. That design has a sharp edge —
+**hooks are resolved by name via `getattr`, with no base-class enforcement**, so a
+misspelled method is silently never called rather than raising. Several of JF's other
+failure modes are similarly quiet, or produce a traceback pointing somewhere unrelated
+to the real cause.
+
+This skill encodes that knowledge: the hook contract, the CLI flags that are genuinely
+JF's (versus ones a project added), checkpoint and `checkpoint.list` semantics, and a
+symptom → cause → fix catalog.
+
+## What it covers
+
+| | |
+|---|---|
+| **Hook contract** | `inference` / `loss` / `accuracy` / `post_process` / `pretreatment` / `load_model`, `get_train_dataset` / `save_result` — signatures, the list-wrapping rule, and the silent-dispatch trap |
+| **CLI** | JF's own flags, and the conventions that surprise people (`--gpu` is a count; `--dataloaderType` defaults to `mapstyle`; `--imgNum` drives the progress bar rather than limiting the data) |
+| **Checkpoints** | `--modelDir` as either a directory with `checkpoint.list` or a `.pth` file; the two-line list format; which line actually loads; warm-starting from a prior run |
+| **Debugging** | Why an empty `ProcessRaisedException` means frozen parameters, why a test run can finish without its merged CSV, why a progress bar that can't reach 100% means auto-save will never fire |
+
+## Install
+
+### As a plugin (gets updates)
+
+```
+/plugin marketplace add Archaic-Atom/JackFramework
+/plugin install jackframework
+```
+
+### As a plain skill (copy it)
+
+The skill is a self-contained directory, so it also works by copying:
+
+```bash
+git clone https://github.com/Archaic-Atom/JackFramework.git
+cp -r JackFramework/plugins/jackframework/skills/jackframework ~/.claude/skills/
+```
+
+Use `.claude/skills/` inside a project instead of `~/.claude/skills/` if you want it
+scoped to one repository.
+
+## Using it
+
+Nothing to invoke — the skill declares when it applies, and Claude consults it when a
+task involves JF. In practice it triggers on things like:
+
+- "my training runs but the loss function never gets called"
+- "4-GPU training dies with ProcessRaisedException and no traceback"
+- "the eval finished but there's no csv in the output dir"
+- "how do I evaluate just one epoch's checkpoint"
+
+You can also load it explicitly with `/jackframework`.
+
+## Scope
+
+The skill describes the framework, not any particular project built on it. Where
+behavior depends on the project (config-driven architecture flags, the dataloader zoo,
+custom CLI flags added in `user_interface.py`), it says so and tells the assistant to
+check the project rather than assume.
+
+Framework behavior changes over time. The one version-sensitive item called out in the
+skill is `--modelDir` accepting a `.pth` file directly, which older checkouts do not
+support — on those, the run fails during init at `FileHandler.mkdir`.

--- a/plugins/jackframework/skills/jackframework/SKILL.md
+++ b/plugins/jackframework/skills/jackframework/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: jackframework
+description: >-
+  How to build on, launch, and debug JackFramework (JF) — a PyTorch training
+  framework that owns the training loop, DDP launcher, checkpoint I/O and progress bar
+  while you supply a model-interface class, a dataloader class and a launcher. Use this
+  whenever a task touches JF hooks (inference / loss / accuracy / post_process /
+  get_train_dataset / save_result), launching `python Source/main.py --mode train|test`,
+  JF CLI flags (--modelDir --modelName --dataset --dist --gpu --imgNum --dataloaderType),
+  checkpoints and checkpoint.list, warm-starting from a prior .pth, or any JF run that
+  failed. Trigger it even when JF is never named — e.g. "training silently skips my loss
+  function", "dies with an empty ProcessRaisedException", "the progress bar never reaches
+  100%", "checkpoint list file not found", "the eval finished but there's no output csv",
+  "how do I resume from epoch 4". Most JF failures are silent, or put the traceback
+  nowhere near the real cause, so consult this before guessing at a fix.
+---
+
+# JackFramework (JF)
+
+JF is a training framework built around string dispatch and a per-project config.
+The deal it offers: it owns the **training loop, DDP launcher, checkpoint I/O,
+logging, progress bar and resume**, and in exchange you implement a **model-interface
+class**, a **dataloader class**, and a thin launcher script.
+
+That deal has one sharp edge that causes most of the pain: **JF finds your code by
+string name via `getattr`, with no abstract base class and no validation.** A method
+you spelled slightly wrong is not an error — it is silently never called. Keep that
+in mind and most JF debugging becomes tractable.
+
+The framework is installed separately from the project that uses it. Confirm which
+copy is actually imported before debugging framework behavior — a stale `.egg` next
+to a source checkout is a classic time sink:
+
+```bash
+python -c "import JackFramework; print(JackFramework.__path__)"
+pip show JackFramework          # 'Editable project location' if installed -e
+```
+
+Use `__path__`, not `__file__`: for a namespace-style install `__file__` is `None`.
+
+## The user-side contract
+
+Everything below is dispatched by name. Copy signatures verbatim from a working
+example rather than retyping them.
+
+**Model interface** (subclass of `ModelHandlerTemplate`):
+
+| hook | contract |
+|---|---|
+| `inference(model, input_data, model_id)` | **returns a LIST** — `[output_dict]` — even with a single model |
+| `loss(output_data, label_data, model_id)` | `output_data` is that LIST; unwrap with `output_data[self.ID_PRED]` (=`[0]`). Returns `[total, *components]` |
+| `accuracy(output_data, label_data, model_id)` | same list-unwrap; returns `[metrics]` |
+| `post_process(epoch, rank, ave_tower_loss, ave_tower_acc)` | **underscore**, not `postprocess`. Once per epoch (train) / after the test loop |
+| `pretreatment(epoch, rank)` | pre-epoch hook |
+| `load_model(model, checkpoint, model_id) -> bool` | often `strict=False` for partial loads / variant inheritance |
+
+**Dataloader** (subclass of `DataHandlerTemplate`):
+
+| hook | contract |
+|---|---|
+| `get_train_dataset(path, is_training=True)` | also called with `is_training=False` for the test set — the name is misleading |
+| `save_result(output_data, supplement, img_id, model_id)` | for `--mode test`; same list-unwrap as loss/accuracy |
+
+Register the dataloader class in the project's dataloader zoo dict; the key is what
+`--dataset` matches, just as `--modelName` matches the model zoo. A missing key
+surfaces as a bare `AssertionError` with no hint, so register before launching.
+
+The list-wrapping rule is the second most common silent failure: `inference()` returns
+`[output]`, but downstream hooks receive that *list*, not the dict. If a check like
+`'<key>' in output_data` is always False, you forgot `output_data[self.ID_PRED]`.
+
+## Launching
+
+There is one entry point — `python Source/main.py <flags>` — with `--mode` selecting
+behavior. JF's own flags are:
+
+```
+--mode --modelName --dataset --dist --gpu --port --ip --nodes --node_rank
+--batchSize --lr --maxEpochs --sampleNum --auto_save_num --pretrain --debug
+--trainListPath --valListPath --imgNum --valImgNum --imgWidth --imgHeight
+--size_magnification --dataloaderNum --dataloaderType
+--modelDir --outputDir --resultImgDir --log --web_cmd
+```
+
+Anything else on a launcher's command line was added by that project's
+`user_interface.py`. Worth checking before assuming a flag is framework behavior —
+projects commonly add their own architecture/loss switches.
+
+Conventions worth internalizing:
+
+- `--gpu` is a **count**, not a device list. Select devices with `CUDA_VISIBLE_DEVICES`.
+- `--port` is the DDP rendezvous port — vary it across concurrent runs or they collide.
+- `--dataloaderType` defaults to `mapstyle`. An iterable/WebDataset pipeline needs it
+  passed **explicitly**.
+- `--imgNum` does **not** limit how much data is processed — it drives the progress bar
+  (`imgNum / batchSize`, per rank under DDP). Everything the dataloader yields is
+  processed either way: a map-style run walks the whole list, and an iterable run
+  drains each rank's shard share until `StopIteration`. So a bar reading `64/64` can
+  have processed every one of 2000 samples.
+
+  **Set it to the real total sample count anyway.** It is the one number that makes
+  the bar and the ETA meaningful, and a wrong value is not always cosmetic: if the
+  project's dataloader also applies a length cap derived from it (see pitfall 5), a
+  too-large value can make the epoch never end, so auto-save never fires. Treat a bar
+  that cannot reach 100% as a real alarm.
+- On a config-driven project, some architecture/loss flags are **inert** — the config
+  file wins. Launchers often pass them anyway "for parity", which misleads readers.
+  Check the config before believing a flag did anything.
+
+## Checkpoints
+
+`--modelDir` accepts **either** form:
+
+- **a directory** — JF reads `checkpoint.list` inside it to pick the file. Without that
+  file you get `Checkpoint list file not found` and nothing loads.
+- **a `.pth` file** — loaded directly. New checkpoints are then written **alongside
+  it**, into its parent directory.
+
+The file form needs a JF new enough to include the `--modelDir`-takes-a-file change.
+On older copies the run dies during init at `FileHandler.mkdir` with `Unable to create
+directory because a file already exists`, because bootstrap tried to `mkdir` the file
+name — the traceback names `init_handler.py`, which reads as unrelated to checkpoints.
+
+`checkpoint.list` is two plain lines, and hand-writing it is a normal, supported move
+when you want to pin one exact epoch:
+
+```
+last model name:model_epoch_4.pth
+model_epoch_4.pth
+```
+
+Saving writes `model_epoch_<N>.pth` every `--auto_save_num` epochs into `--modelDir`
+and puts the newest at the top of that list, so the **first** line is what loads next —
+not necessarily the highest-numbered file in the directory.
+
+Projects often save only a sub-module's `state_dict` (e.g. a trainable head, not a
+frozen backbone). So a checkpoint that loads with `missing=0, unexpected=0` against a
+*different* variant is expected when the variants share that sub-module — it is not
+by itself evidence that you loaded the right thing. Verify against the log line naming
+the loaded file.
+
+To **warm-start a fresh run** from a prior checkpoint, strip the optimizer state and
+reset the epoch counter first; otherwise JF resumes the stored epoch count and your
+new run's schedule and warmup are computed from the wrong epoch.
+
+## Debugging recipe
+
+1. **Reproduce on a single process first** — `--dist False --gpu 1`. This is the single
+   highest-value habit: DDP swallows tracebacks, single-process shows the real error.
+2. **Empty `ProcessRaisedException` with no Python traceback** is almost always DDP
+   hitting a registered parameter that received no gradient — a frozen backbone or
+   encoder is the usual cause. It looks like a C-level crash but it isn't. Fix by
+   genuinely setting `requires_grad=False` before the model is wrapped, or with
+   `find_unused_parameters=True` in JF's DDP wrap.
+3. **A hook seems to do nothing** → suspect the name before the logic.
+4. **`--mode test` finished but there's no output CSV** → the step that merges the
+   per-rank temp files runs after the loop and can lag or hang. No data is at risk:
+   predictions are already in `<outputDir>/.tmp_test_*_rank<N>.csv` (leading dot — plain
+   `ls` hides it). Read or concatenate those rather than re-running.
+5. **Progress bar never reaches 100% and auto-save never fires** → a per-worker length
+   cap applied as if it were global. See pitfall 5.
+
+For the full symptom→cause catalog, read `references/pitfalls.md`.
+
+## Working style
+
+When something breaks, prefer a **surgical patch** in the project over changing the
+framework, and keep framework patches minimal and recorded — a JF patch lives in the
+JF install rather than the project's version control, so a reinstall silently reverts
+it and the next person re-diagnoses from scratch.
+
+When you do patch JF itself, verify the change by *running* it, not by reading it. The
+init and checkpoint paths in particular have ordering that is hard to predict from
+source — the mkdir-before-validate ordering described above is exactly the kind of
+thing that reading gets wrong.

--- a/plugins/jackframework/skills/jackframework/references/pitfalls.md
+++ b/plugins/jackframework/skills/jackframework/references/pitfalls.md
@@ -1,0 +1,201 @@
+# JF pitfall catalog — symptom → cause → fix
+
+Ordered roughly by how often each one bites. Every entry starts from the *symptom*,
+because that is what you actually have when you arrive.
+
+## Contents
+
+1. [A hook never runs](#1-a-hook-never-runs)
+2. [`'<key>' not in output_data` forever](#2-key-not-in-output_data-forever)
+3. [Empty `ProcessRaisedException` on multi-GPU](#3-empty-processraisedexception-on-multi-gpu)
+4. [Bare `AssertionError` at startup](#4-bare-assertionerror-at-startup)
+5. [Progress bar never reaches 100%, no auto-save](#5-progress-bar-never-reaches-100-no-auto-save)
+6. [Checkpoint didn't load / loaded the wrong epoch](#6-checkpoint-didnt-load--loaded-the-wrong-epoch)
+7. [`--mode test` produced no output CSV](#7---mode-test-produced-no-output-csv)
+8. [A CLI flag appears to be ignored](#8-a-cli-flag-appears-to-be-ignored)
+9. [Editing JF has no effect](#9-editing-jf-has-no-effect)
+10. [Indices collide in saved results](#10-indices-collide-in-saved-results)
+
+---
+
+## 1. A hook never runs
+
+**Symptom** — training proceeds but your loss/metric/post-processing clearly never
+executes. No error anywhere.
+
+**Cause** — JF dispatches user methods by string name with `getattr`. There is no ABC
+and no validation, so a misspelling is indistinguishable from "the user didn't
+implement this hook". The classic is `postprocess` vs the correct `post_process`; wrong
+case and singular/plural slips do the same thing. Because the template base class
+supplies a no-op default, the call still succeeds — it just runs the empty parent.
+
+**Fix** — diff your method names against a working example rather than against memory.
+If you want a guardrail, assert on `hasattr` in your own `__init__`.
+
+## 2. `'<key>' not in output_data` forever
+
+**Symptom** — a downstream hook insists a key you definitely produced is missing.
+
+**Cause** — `inference()` returns a **list** (`[output_dict]`). `loss()`, `accuracy()`
+and `save_result()` receive that list, not the dict inside it.
+
+**Fix** — unwrap first: `pred = output_data[self.ID_PRED]` (`ID_PRED` is `0`). This
+applies to every hook downstream of `inference`, which is why it tends to be fixed in
+one place and forgotten in another.
+
+## 3. Empty `ProcessRaisedException` on multi-GPU
+
+**Symptom** — a DDP run aborts with `ProcessRaisedException` and no Python traceback.
+Looks like a C-level crash.
+
+**Cause** — a registered parameter received no gradient, so the reducer aborted in C++
+rather than raising a Python exception, leaving nothing to propagate back. In practice
+this means part of the model is frozen while still being registered with DDP.
+
+**Fixes**, in order of preference:
+
+1. **Freeze properly and early** — set `requires_grad=False` on the frozen module when
+   the model is built, before JF wraps it. DDP snapshots which parameters expect
+   gradients at construction time, so freezing later (e.g. inside `pretreatment()`) is
+   too late to matter.
+2. **`find_unused_parameters=True`** in JF's DDP wrap. This costs a little per-step
+   overhead but also makes the *real* error surface if the cause was something else.
+3. **`static_graph=True`** if the graph is structurally constant, as a cheaper
+   alternative to (2).
+
+To locate the offending parameters, run one process and list what has
+`requires_grad=True` but a `None` gradient after a backward pass. Also useful:
+`TORCH_DISTRIBUTED_DEBUG=DETAIL` makes PyTorch name them for you.
+
+**Always confirm on `--dist False --gpu 1` first** — single-process gives a real
+traceback, so you learn whether you even have a DDP problem.
+
+A JF-side patch such as (2) lives in the JF install, not the project's version control,
+so a reinstall silently reverts it. Check whether the patch is still present before
+re-diagnosing.
+
+## 4. Bare `AssertionError` at startup
+
+**Symptom** — an assertion fires before training starts, with no message.
+
+**Cause** — a registry lookup missed: `--dataset` has no matching key in the dataloader
+zoo, or `--modelName` has none in the model zoo.
+
+**Fix** — grep the zoo dict and compare the exact string. Register new variants *before*
+launching; JF will not tell you which key it wanted.
+
+## 5. Progress bar never reaches 100%, no auto-save
+
+**Symptom** — the bar stalls short of the end, and because the epoch never "completes",
+`--auto_save_num` never triggers, so a long run produces zero checkpoints. This failure
+is expensive precisely because it looks like slow progress rather than a bug — it can
+burn a multi-day run before anyone notices there are no saves.
+
+**Cause** — a per-worker length cap applied as if it were global. With WebDataset,
+`with_epoch(N)` yields N samples **per worker**, so the real epoch is
+`world_size × num_workers × N` — e.g. ~32× over-iteration on a 4-GPU / 8-worker setup.
+The bar hits 100% (it is drawn from `imgNum / batchSize`) and the loop just keeps going,
+so the epoch never ends and no save fires.
+
+**Fix** — the settled answer is to **remove `with_epoch` entirely** and let
+`split_by_node` + `split_by_worker` partition the shards, so each worker drains its own
+share once and `StopIteration` propagates naturally. Dividing the cap by `world_size`,
+or by `world_size × num_workers`, are both still wrong (the latter under-counts whenever
+a rank has fewer shards than workers, leaving some workers idle).
+
+Then set `--imgNum` to the **true total sample count** so the bar means something. Under
+DDP the first epoch's bar can still read `world_size`× too high; JF self-corrects on
+later epochs and logs "input images numbers is different the number of datasets" once.
+That single log line is expected — it is not the bug.
+
+## 6. Checkpoint didn't load / loaded the wrong epoch
+
+**Symptom** — `Checkpoint list file not found`, or the run silently starts from scratch,
+or it resumes an epoch you didn't intend.
+
+**Cause and fix** — depends on what `--modelDir` points at:
+
+- **A directory without `checkpoint.list`** → nothing loads. Write the two-line file:
+  ```
+  last model name:model_epoch_4.pth
+  model_epoch_4.pth
+  ```
+  The **first** line is what gets loaded (JF reads row 1 and strips the
+  `last model name:` prefix); entries below it are history. So the file that loads is
+  not necessarily the highest-numbered `.pth` in the directory — pinning one exact epoch
+  by hand is normal practice for evaluation.
+- **A `.pth` file** → loaded directly; new saves land in its parent directory. Requires a
+  JF new enough to include the `--modelDir`-takes-a-file change. On an older copy the run
+  dies in init at `FileHandler.mkdir` with `Unable to create directory because a file
+  already exists` — the traceback names `init_handler.py`, which is why this reads as
+  unrelated to checkpoints.
+- **Resuming an unintended epoch** → the checkpoint still carries its optimizer state and
+  epoch counter. For a *fresh* run warm-started from old weights, strip both first,
+  otherwise the schedule and any warmup are computed from the wrong epoch.
+
+`missing=0, unexpected=0` when loading across two variants is **expected** if they share
+the saved sub-module — many projects save only a trainable head rather than the whole
+model. It is not by itself evidence that you loaded the right thing; confirm against the
+log line naming the file that was loaded.
+
+A related silent failure: `load_model()` is often `strict=False`, so a `module.` prefix
+mismatch (a checkpoint trained under DDP, evaluated with `--dist False`) can drop every
+key and still produce a complete, plausible-looking run on random weights. Check the
+missing/unexpected counts, not just that the run finished.
+
+## 7. `--mode test` produced no output CSV
+
+**Symptom** — the progress bar hit 100%, the process is idle or was killed, and the
+merged `test_<dataset>_<timestamp>.csv` is missing.
+
+**Cause** — the step that merges the per-rank temp files runs after the loop and can lag
+by minutes, or hang.
+
+**Fix** — nothing is lost. Every prediction is already in
+`<outputDir>/.tmp_test_*_rank<N>.csv` (note the leading dot — plain `ls` hides it). Read
+that file directly, or concatenate the per-rank ones keeping one header. Re-running the
+eval to "get the CSV" wastes GPU time for no new data.
+
+If the temp files are genuinely absent, the failure is upstream instead: the test-mode
+hooks must line up — `inference()` attaching the output, `save_result()` unwrapping the
+list and writing, and `post_process()` doing any final merge. A misspelled hook (pitfall
+1) or a missing list-unwrap (pitfall 2) produces exactly this.
+
+## 8. A CLI flag appears to be ignored
+
+**Symptom** — you pass a flag and nothing changes.
+
+**Cause** — either the flag is not a JF flag at all (projects add their own in
+`user_interface.py`), or on a config-driven project the config file is authoritative for
+architecture/loss values and those CLI flags are inert. Launcher scripts frequently pass
+them anyway for parity with older scripts, which makes them look load-bearing.
+
+**Fix** — check the project's config before believing a flag. Be aware of the inverse
+trap too: when the same quantity exists in both places (a dataloader-side flag and a
+config-side field), nothing cross-checks them, so they must be kept consistent by hand.
+
+## 9. Editing JF has no effect
+
+**Symptom** — you patch a JF source file and the behavior doesn't change.
+
+**Cause** — JF often exists as several copies: a built `.egg` in site-packages, the
+source checkout, and stale `build/` artifacts. You edited one that isn't imported.
+
+**Fix** —
+```bash
+python -c "import JackFramework; print(JackFramework.__path__)"
+pip show JackFramework    # look for 'Editable project location'
+```
+Prefer an editable install of the source for anything you intend to debug. Use
+`__path__`, not `__file__` — the latter is `None` for a namespace-style install.
+
+## 10. Indices collide in saved results
+
+**Symptom** — rows in the output overwrite each other, typically near the end of a run.
+
+**Cause** — a global index computed as `img_id * batch + b` using the *actual* tensor
+size. The final batch is usually partial, so its smaller size shifts every index and
+collides with earlier full batches.
+
+**Fix** — compute the stride from the **configured** batch size (`args.batchSize`), not
+from `tensor.shape[0]`.


### PR DESCRIPTION
## Summary

Adds a [Claude Code](https://claude.com/claude-code) skill that teaches an assistant how
JF actually behaves, so it stops guessing when a run fails.

JF resolves hooks by name via `getattr` with no base-class enforcement, so a misspelled
method is silently never called rather than raising. Several other failure modes are
similarly quiet, or surface a traceback pointing somewhere unrelated to the cause. Those
are exactly the cases where an assistant without this context gives a confident wrong
answer.

## Contents

- `plugins/jackframework/skills/jackframework/SKILL.md` — the hook contract
  (`inference` / `loss` / `accuracy` / `post_process` / `get_train_dataset` /
  `save_result`) and its list-wrapping rule; JF's own CLI flags versus ones a project
  adds in `user_interface.py`; checkpoint and `checkpoint.list` semantics, including
  `--modelDir` accepting either a directory or a `.pth` file; a debugging recipe.
- `.../references/pitfalls.md` — a symptom → cause → fix catalog of ten failure modes,
  ordered by how often they bite.
- `plugins/jackframework/README.md` — install instructions.
- `.claude-plugin/marketplace.json` — makes this repo addable as a plugin marketplace.

## Install

```
/plugin marketplace add Archaic-Atom/JackFramework
/plugin install jackframework
```

or copy the directory:

```bash
cp -r plugins/jackframework/skills/jackframework ~/.claude/skills/
```

## Scope

Documents the framework only. Where behavior depends on the project built on JF
(config-driven flags, the dataloader zoo, project-added CLI flags), the skill says so
and tells the assistant to check the project rather than assume.

The CLI flag list was taken from `args_parser.py` rather than from memory — flags a
downstream project had added were initially misattributed to JF and have been removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cbeju55q6Nk2mFk1yR8C8a

## Summary by Sourcery

Add a Claude Code skill for JackFramework that documents its hooks, CLI usage, checkpoint semantics, and common debugging workflows.

Documentation:
- Introduce SKILL documentation describing JackFramework’s user-facing contracts, launch flags, checkpoint behavior, and recommended debugging practices.
- Add a pitfall catalog outlining frequent JackFramework failure modes with symptom–cause–fix guidance.
- Document installation and usage of the JackFramework Claude Code skill in a dedicated README.

Chores:
- Add plugin metadata to integrate the JackFramework skill with the Claude plugin marketplace.